### PR TITLE
Fix push failure reporting when using -p flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.17.2] - 2025-09-14
+
+### Fixed
+
+- **Push Failure Reporting**: Fixed issue where git push failures were incorrectly reported as successful when using the `-p` flag
+  - Updated `push_changes()` function to use `run_subprocess()` with `raise_on_error=True` for accurate failure detection
+  - Replaced generic error handling with specific `subprocess.CalledProcessError` handling to capture git push stderr output
+  - Modified main function to properly exit with error code 1 when push operations fail
+  - Improved error messages to include network connection troubleshooting hints
+  - Updated test suite to match the new implementation and ensure push failures are properly detected
+
 ## [v0.17.0] - 2025-09-14
 
 ### Added

--- a/src/gac/git.py
+++ b/src/gac/git.py
@@ -161,11 +161,16 @@ def push_changes() -> bool:
         return False
 
     try:
-        run_git_command(["push"])
+        # Use raise_on_error=True to properly catch push failures
+        run_subprocess(["git", "push"], raise_on_error=True, strip_output=True)
         return True
-    except GitError as e:
-        if "fatal: No configured push destination" in str(e):
+    except subprocess.CalledProcessError as e:
+        error_msg = e.stderr.strip() if e.stderr else str(e)
+        if "fatal: No configured push destination" in error_msg:
             logger.error("No configured push destination.")
         else:
-            logger.error(f"Failed to push changes: {e}")
+            logger.error(f"Failed to push changes: {error_msg}")
+        return False
+    except Exception as e:
+        logger.error(f"Failed to push changes: {e}")
         return False

--- a/src/gac/main.py
+++ b/src/gac/main.py
@@ -270,15 +270,13 @@ def main(
                 logger.info("Changes pushed successfully")
                 console.print("[green]Changes pushed successfully[/green]")
             else:
-                handle_error(
-                    GitError("Failed to push changes. Check your remote configuration."),
-                    exit_program=True,
+                console.print(
+                    "[red]Failed to push changes. Check your remote configuration and network connection.[/red]"
                 )
+                sys.exit(1)
         except Exception as e:
-            handle_error(
-                GitError(f"Error pushing changes: {e}"),
-                exit_program=True,
-            )
+            console.print(f"[red]Error pushing changes: {e}[/red]")
+            sys.exit(1)
 
     if not quiet:
         logger.info("Successfully committed changes with message:")

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -108,17 +108,27 @@ def test_push_changes_no_remote():
 
 def test_push_changes_success():
     """Test push_changes when push is successful."""
-    with patch("gac.git.run_git_command") as mock_run:
-        mock_run.side_effect = ["origin\n", ""]  # First call for 'git remote', second for 'git push'
+    with patch("gac.git.run_git_command") as mock_run_git, patch("gac.git.run_subprocess") as mock_run_sub:
+        mock_run_git.return_value = "origin\n"  # For 'git remote'
+        mock_run_sub.return_value = ""  # For 'git push'
         result = push_changes()
         assert result is True
-        assert mock_run.call_count == 2
+        mock_run_git.assert_called_once_with(["remote"])
+        mock_run_sub.assert_called_once_with(["git", "push"], raise_on_error=True, strip_output=True)
 
 
 def test_push_changes_git_error():
-    """Test push_changes when GitError is raised."""
-    with patch("gac.git.run_git_command") as mock_run, patch("gac.git.logger") as mock_logger:
-        mock_run.side_effect = ["origin\n", GitError("Failed to push")]  # First call for 'git remote'
+    """Test push_changes when push fails with CalledProcessError."""
+    import subprocess
+
+    with (
+        patch("gac.git.run_git_command") as mock_run_git,
+        patch("gac.git.run_subprocess") as mock_run_sub,
+        patch("gac.git.logger") as mock_logger,
+    ):
+        mock_run_git.return_value = "origin\n"  # For 'git remote'
+        error = subprocess.CalledProcessError(1, ["git", "push"], "", "Failed to push")
+        mock_run_sub.side_effect = error
         result = push_changes()
         assert result is False
         mock_logger.error.assert_called_once_with("Failed to push changes: Failed to push")
@@ -126,11 +136,16 @@ def test_push_changes_git_error():
 
 def test_push_changes_fatal_error():
     """Test push_changes when fatal error occurs."""
-    with patch("gac.git.run_git_command") as mock_run, patch("gac.git.logger") as mock_logger:
-        mock_run.side_effect = [  # First call for 'git remote'
-            "origin\n",
-            GitError("fatal: No configured push destination"),
-        ]
+    import subprocess
+
+    with (
+        patch("gac.git.run_git_command") as mock_run_git,
+        patch("gac.git.run_subprocess") as mock_run_sub,
+        patch("gac.git.logger") as mock_logger,
+    ):
+        mock_run_git.return_value = "origin\n"  # For 'git remote'
+        error = subprocess.CalledProcessError(1, ["git", "push"], "", "fatal: No configured push destination")
+        mock_run_sub.side_effect = error
         result = push_changes()
         assert result is False
         mock_logger.error.assert_called_once_with("No configured push destination.")


### PR DESCRIPTION
## Summary
- Fixed issue where `gac -p` incorrectly reported push success even when git push failed
- Improved error handling and reporting for push operations
- Updated test suite to verify correct failure detection

## Problem
When using the `-p` flag to have gac perform a git push, if the git push failed it would still report that it pushed successfully. This was due to improper error handling in the `push_changes()` function.

## Solution
- Updated `push_changes()` to use `run_subprocess()` with `raise_on_error=True` for accurate failure detection
- Replaced generic error handling with specific `subprocess.CalledProcessError` handling
- Modified main function to properly exit with error code 1 when push fails
- Enhanced error messages to include network troubleshooting hints

## Test Plan
- [x] Updated existing tests for push_changes function
- [x] All tests pass (`pytest tests/`)
- [x] Manually tested push failure scenarios
- [x] Verified proper error messages and exit codes

🤖 Generated with [Claude Code](https://claude.ai/code)