### PR TITLE
Switch to tag-based releases for better control

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.2
+current_version = 0.17.3
 commit = False
 tag = False
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,7 @@
-# Publishes your package to PyPI using Astral/uv for builds.
-# Set PYPI_API_TOKEN in repo secrets.
+# Publishes your package to PyPI when version is manually bumped
+# Requires PYPI_API_TOKEN in repo secrets
 
-permissions:
-  contents: write # Allows writing to the repository
-
-name: Build and Publish to PyPI
+name: Publish to PyPI
 
 on:
   push:
@@ -12,197 +9,56 @@ on:
       - main
 
 jobs:
-  build-publish:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # Allows writing to the repository
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Need full history for version detection
+          fetch-depth: 2 # Need current and previous commit
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
-        run: pip install uv build twine bump-my-version packaging
-
-      - name: Setup uv virtual environment
-        run: uv venv
-
-      - name: Check if version bump is needed
+      - name: Check if version was bumped
         id: version_check
         run: |
-          echo "=== Version Bump Check ==="
+          echo "=== Checking for version bump ==="
 
-          # Skip if recent commits have skip flags
-          if git log --oneline -5 | grep -qiE '\[(skip-version-bump|skip-auto-bump|no-auto-bump|version-bump-done|ci skip)\]'; then
-            echo "Skip flag detected in recent commits"
-            echo "skip_auto_bump=true" >> $GITHUB_OUTPUT
-            exit 0
+          # Get current version
+          CURRENT_VERSION=$(grep '__version__' src/gac/__version__.py | sed 's/.*"\(.*\)".*/\1/')
+          echo "Current version: $CURRENT_VERSION"
+
+          # Get previous version from parent commit
+          PREVIOUS_VERSION=$(git show HEAD^:src/gac/__version__.py | grep '__version__' | sed 's/.*"\(.*\)".*/\1/' || echo "0.0.0")
+          echo "Previous version: $PREVIOUS_VERSION"
+
+          # Compare versions
+          if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
+            echo "::notice::Version unchanged ($CURRENT_VERSION). Skipping publish."
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::Version bumped from $PREVIOUS_VERSION to $CURRENT_VERSION. Publishing to PyPI."
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+            echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           fi
 
-          python3 << 'EOF'
-          import re
-          import subprocess
-          import sys
-          import os
-          from packaging import version
-
-          def get_version_from_file(file_path):
-              """Read version from __version__.py file"""
-              try:
-                  with open(file_path, 'r') as f:
-                      content = f.read()
-                      match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', content)
-                      return match.group(1) if match else None
-              except FileNotFoundError:
-                  return None
-
-          def get_version_at_commit(commit, file_path):
-              """Get version from a file at a specific commit"""
-              try:
-                  result = subprocess.run(
-                      ['git', 'show', f'{commit}:{file_path}'],
-                      capture_output=True, text=True, check=True
-                  )
-                  match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', result.stdout)
-                  return match.group(1) if match else None
-              except subprocess.CalledProcessError:
-                  return None
-
-          def get_last_version_on_main():
-              """Get the last published version from main branch"""
-              try:
-                  # Get the parent commit on main (before the current merge)
-                  result = subprocess.run(
-                      ['git', 'rev-parse', 'HEAD~1'],
-                      capture_output=True, text=True, check=True
-                  )
-                  parent_commit = result.stdout.strip()
-                  return get_version_at_commit(parent_commit, 'src/gac/__version__.py')
-              except subprocess.CalledProcessError:
-                  return None
-
-          def parse_version_bump_type(current, previous):
-              """Determine what type of version bump occurred"""
-              if not current or not previous:
-                  return None
-              
-              curr = version.parse(current)
-              prev = version.parse(previous)
-              
-              if curr.major > prev.major:
-                  return "major"
-              elif curr.minor > prev.minor:
-                  return "minor"
-              elif curr.micro > prev.micro:
-                  return "patch"
-              else:
-                  return None
-
-          # Get versions
-          current_version = get_version_from_file('src/gac/__version__.py')
-          previous_version = get_last_version_on_main()
-
-          print(f"Current version: {current_version}")
-          print(f"Previous version on main: {previous_version}")
-
-          # Check if version was already bumped
-          skip_bump = False
-
-          if not current_version:
-              print("ERROR: Could not read current version")
-              sys.exit(1)
-
-          if not previous_version:
-              print("WARNING: Could not read previous version, assuming first release")
-              skip_bump = False
-          elif current_version == previous_version:
-              print("Version unchanged - will apply patch bump")
-              skip_bump = False
-          else:
-              curr_v = version.parse(current_version)
-              prev_v = version.parse(previous_version)
-              
-              if curr_v > prev_v:
-                  bump_type = parse_version_bump_type(current_version, previous_version)
-                  print(f"Version already bumped ({bump_type}): {previous_version} -> {current_version}")
-                  skip_bump = True
-              elif curr_v < prev_v:
-                  print(f"ERROR: Current version ({current_version}) is lower than previous ({previous_version})")
-                  sys.exit(1)
-              else:
-                  print("Version unchanged - will apply patch bump")
-                  skip_bump = False
-
-          # Sync .bumpversion.cfg if needed
-          try:
-              with open('.bumpversion.cfg', 'r') as f:
-                  cfg_content = f.read()
-                  cfg_match = re.search(r'current_version\s*=\s*([^\n]+)', cfg_content)
-                  cfg_version = cfg_match.group(1).strip() if cfg_match else None
-              
-              if cfg_version != current_version:
-                  print(f"Syncing .bumpversion.cfg: {cfg_version} -> {current_version}")
-                  new_content = re.sub(
-                      r'current_version\s*=\s*[^\n]+',
-                      f'current_version = {current_version}',
-                      cfg_content
-                  )
-                  with open('.bumpversion.cfg', 'w') as f:
-                      f.write(new_content)
-          except FileNotFoundError:
-              print("Creating .bumpversion.cfg")
-              with open('.bumpversion.cfg', 'w') as f:
-                  f.write(f'''[bumpversion]
-          current_version = {current_version}
-          commit = False
-          tag = False
-
-          [bumpversion:file:src/gac/__version__.py]
-          ''')
-
-          # Write output
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f"skip_auto_bump={'true' if skip_bump else 'false'}\n")
-              f.write(f"current_version={current_version}\n")
-              f.write(f"previous_version={previous_version or '0.0.0'}\n")
-
-          if skip_bump:
-              print("\n✅ Skipping auto-bump - version already updated")
-          else:
-              print("\n⚙ Will apply patch bump")
-
-          sys.exit(0)
-          EOF
-
-      - name: Apply automatic version bump
-        if: steps.version_check.outputs.skip_auto_bump != 'true'
-        run: |
-          echo "Applying automatic patch version bump..."
-          bump-my-version bump patch --allow-dirty
+      - name: Install uv
+        if: steps.version_check.outputs.version_changed == 'true'
+        run: pip install uv
 
       - name: Build package
-        run: |
-          uv build
+        if: steps.version_check.outputs.version_changed == 'true'
+        run: uv build
 
       - name: Publish to PyPI
+        if: steps.version_check.outputs.version_changed == 'true'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: uv run twine upload dist/*
-
-      - name: Push version bump to GitHub
-        if: ${{ success() }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add .
-          git commit -m "chore: bump version [ci skip]" || echo "No changes to commit"
-          git push
+          uv pip install --system twine
+          twine upload dist/*
+          echo "::notice::Successfully published version ${{ steps.version_check.outputs.current_version }} to PyPI"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,12 @@
-# Publishes your package to PyPI when version is manually bumped
+# Publishes package to PyPI when a version tag is pushed
 # Requires PYPI_API_TOKEN in repo secrets
 
 name: Publish to PyPI
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # Matches tags like v0.17.3
 
 jobs:
   publish:
@@ -14,51 +14,48 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 2 # Need current and previous commit
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Check if version was bumped
-        id: version_check
+      - name: Extract version from tag
+        id: get_version
         run: |
-          echo "=== Checking for version bump ==="
+          # Get tag name from GITHUB_REF (refs/tags/v0.17.3 -> v0.17.3)
+          TAG=${GITHUB_REF#refs/tags/}
+          # Remove 'v' prefix to get version number
+          VERSION=${TAG#v}
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing version $VERSION from tag $TAG"
 
-          # Get current version
-          CURRENT_VERSION=$(grep '__version__' src/gac/__version__.py | sed 's/.*"\(.*\)".*/\1/')
-          echo "Current version: $CURRENT_VERSION"
+      - name: Verify version matches code
+        run: |
+          # Get version from code
+          CODE_VERSION=$(grep '__version__' src/gac/__version__.py | sed 's/.*"\(.*\)".*/\1/')
+          TAG_VERSION=${{ steps.get_version.outputs.version }}
 
-          # Get previous version from parent commit
-          PREVIOUS_VERSION=$(git show HEAD^:src/gac/__version__.py | grep '__version__' | sed 's/.*"\(.*\)".*/\1/' || echo "0.0.0")
-          echo "Previous version: $PREVIOUS_VERSION"
-
-          # Compare versions
-          if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
-            echo "::notice::Version unchanged ($CURRENT_VERSION). Skipping publish."
-            echo "version_changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "::notice::Version bumped from $PREVIOUS_VERSION to $CURRENT_VERSION. Publishing to PyPI."
-            echo "version_changed=true" >> $GITHUB_OUTPUT
-            echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          if [ "$CODE_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Version mismatch! Code has $CODE_VERSION but tag is v$TAG_VERSION"
+            echo "Please ensure src/gac/__version__.py matches the tag version"
+            exit 1
           fi
 
+          echo "✅ Version verified: $CODE_VERSION"
+
       - name: Install uv
-        if: steps.version_check.outputs.version_changed == 'true'
         run: pip install uv
 
       - name: Build package
-        if: steps.version_check.outputs.version_changed == 'true'
         run: uv build
 
       - name: Publish to PyPI
-        if: steps.version_check.outputs.version_changed == 'true'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           uv pip install --system twine
           twine upload dist/*
-          echo "::notice::Successfully published version ${{ steps.version_check.outputs.current_version }} to PyPI"
+          echo "::notice::Successfully published version ${{ steps.get_version.outputs.version }} to PyPI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- **Simplified CI/CD Publishing Workflow**: Removed complex auto-version-bumping logic in favor of manual version bumps
-  - CI now only publishes to PyPI when it detects a manual version change in PRs
-  - Prevents "file already exists" errors from duplicate publish attempts
-  - Makes version management more explicit and predictable
-  - Updated contributing guidelines to document version bump requirements
+- **Tag-Based Release Workflow**: Switched to tag-triggered releases for better control
+  - CI/CD now publishes to PyPI only when version tags are pushed (e.g., `v0.17.3`)
+  - Removed complex auto-version-bumping logic
+  - Allows batching multiple PRs before releasing
+  - Prevents accidental releases and "file already exists" errors
+  - Verifies tag version matches code version before publishing
+  - Updated documentation to explain tag-based release process
 
 ## [v0.17.2] - 2025-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.17.3] - 2025-09-14
+
+### Changed
+
+- **Simplified CI/CD Publishing Workflow**: Removed complex auto-version-bumping logic in favor of manual version bumps
+  - CI now only publishes to PyPI when it detects a manual version change in PRs
+  - Prevents "file already exists" errors from duplicate publish attempts
+  - Makes version management more explicit and predictable
+  - Updated contributing guidelines to document version bump requirements
+
 ## [v0.17.2] - 2025-09-14
 
 ### Fixed

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,9 @@ make the process smooth for everyone.
 - [Contributing to gac](#contributing-to-gac)
   - [Table of Contents](#table-of-contents)
   - [How to Contribute](#how-to-contribute)
+  - [Version Bumping](#version-bumping)
   - [Coding Standards](#coding-standards)
+  - [Pre-commit Hooks](#pre-commit-hooks)
   - [Testing Guidelines](#testing-guidelines)
     - [Running Tests](#running-tests)
   - [Code of Conduct](#code-of-conduct)
@@ -25,10 +27,47 @@ make the process smooth for everyone.
   2. Make your changes following the coding standards below.
   3. Add or update tests as needed.
   4. Ensure all tests pass (`pytest`).
-  5. Submit a pull request with a clear description of your changes.
+  5. **Bump the version** in `src/gac/__version__.py` (see Version Bumping section below).
+  6. Update `CHANGELOG.md` with your changes.
+  7. Submit a pull request with a clear description of your changes.
 
 If you have questions or want to discuss ideas before contributing, please open an issue or start a discussion on
 GitHub.
+
+## Version Bumping
+
+**Important**: All PRs that include changes to the codebase must bump the version number.
+The CI/CD pipeline will only publish to PyPI when it detects a version change.
+
+### How to bump the version
+
+1. Edit `src/gac/__version__.py` and increment the version number
+2. Follow [Semantic Versioning](https://semver.org/):
+   - **Patch** (0.0.X): Bug fixes, small improvements
+   - **Minor** (0.X.0): New features, backwards-compatible changes
+   - **Major** (X.0.0): Breaking changes
+
+Example:
+
+```python
+# src/gac/__version__.py
+__version__ = "0.17.3"  # Bumped from 0.17.2
+```
+
+### Using bump-my-version (optional)
+
+If you have `bump-my-version` installed, you can use it locally:
+
+```bash
+# For bug fixes:
+bump-my-version bump patch
+
+# For new features:
+bump-my-version bump minor
+
+# For breaking changes:
+bump-my-version bump major
+```
 
 ## Coding Standards
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,7 +27,7 @@ make the process smooth for everyone.
   2. Make your changes following the coding standards below.
   3. Add or update tests as needed.
   4. Ensure all tests pass (`pytest`).
-  5. **Bump the version** in `src/gac/__version__.py` (see Version Bumping section below).
+  5. Bump the version in `src/gac/__version__.py` if this is a releasable change.
   6. Update `CHANGELOG.md` with your changes.
   7. Submit a pull request with a clear description of your changes.
 
@@ -36,8 +36,7 @@ GitHub.
 
 ## Version Bumping
 
-**Important**: All PRs that include changes to the codebase must bump the version number.
-The CI/CD pipeline will only publish to PyPI when it detects a version change.
+**Important**: PRs should include a version bump in `src/gac/__version__.py` when they contain changes that should be released.
 
 ### How to bump the version
 
@@ -46,6 +45,15 @@ The CI/CD pipeline will only publish to PyPI when it detects a version change.
    - **Patch** (0.0.X): Bug fixes, small improvements
    - **Minor** (0.X.0): New features, backwards-compatible changes
    - **Major** (X.0.0): Breaking changes
+
+### Release Process
+
+Releases are triggered by pushing version tags:
+
+1. Merge PR(s) with version bumps to main
+2. Create a tag: `git tag v0.17.3`
+3. Push the tag: `git push origin v0.17.3`
+4. GitHub Actions automatically publishes to PyPI
 
 Example:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -46,8 +46,6 @@ This document outlines the process for releasing new versions of GAC to PyPI.
 
 ### 2. Version Bump
 
-**IMPORTANT**: Version must be bumped in the PR for CI to publish!
-
 Update version in `src/gac/__version__.py`:
 
 ```python
@@ -117,30 +115,38 @@ gac --version
 twine upload dist/*
 ```
 
-### 7. Post-release
+### 7. Create Release Tag
+
+**This step triggers the automated PyPI release!**
+
+```bash
+# Create and push the version tag
+git tag v0.15.0  # Use your actual version
+git push origin v0.15.0
+
+# GitHub Actions will now:
+# 1. Build the package
+# 2. Verify version matches tag
+# 3. Upload to PyPI
+```
+
+Monitor the [Actions tab](https://github.com/cellwebb/gac/actions) to ensure successful publication.
+
+### 8. Post-release
 
 1. **Verify the release on PyPI**:
 
    - Check [PyPI project page](https://pypi.org/project/gac/)
    - Ensure the new version is listed
 
-2. **Optional: Create Git tag** (for reference):
-
-   ```bash
-   git tag -a v0.15.0 -m "Release version 0.15.0"
-   git push origin v0.15.0
-   ```
-
-   Note: Tags are optional since CI publishes based on version changes, not tags.
-
-3. **Verify Installation**:
+2. **Verify Installation**:
 
    ```bash
    pipx install --force gac
    gac --version
    ```
 
-4. **Update Documentation**:
+3. **Update Documentation**:
    - Update README if needed
    - Update installation instructions to reference PyPI
 
@@ -148,20 +154,32 @@ twine upload dist/*
 
 The project includes `.github/workflows/publish.yml` for automated releases:
 
-- Triggers automatically when code is pushed to `main` branch
-- **Only publishes if the version in `src/gac/__version__.py` has been bumped**
+- Triggers when you push a version tag (e.g., `v0.17.3`)
+- Verifies the tag version matches `src/gac/__version__.py`
+- Automatically builds and publishes to PyPI
 - Requires `PYPI_API_TOKEN` secret in repository settings
-- No manual tagging required
 
 ### How it works
 
-1. Create a PR with your changes
-2. **Bump the version** in `src/gac/__version__.py`
-3. Update `CHANGELOG.md`
-4. Merge the PR to main
-5. CI automatically publishes to PyPI if version changed
+1. Merge your PR(s) to main with version bumped in `src/gac/__version__.py`
+2. When ready to release, create and push a tag:
 
-If the version hasn't been bumped, the CI will skip publishing (preventing duplicate uploads).
+   ```bash
+   git checkout main
+   git pull
+   git tag v0.17.3  # Use your version number
+   git push origin v0.17.3
+   ```
+
+3. GitHub Actions automatically publishes to PyPI
+4. The workflow verifies the tag matches the code version
+
+### Benefits
+
+- Full control over when to release
+- Can merge multiple PRs before releasing
+- Tags provide clear release history
+- Prevents accidental releases
 
 ## Troubleshooting
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -46,10 +46,25 @@ This document outlines the process for releasing new versions of GAC to PyPI.
 
 ### 2. Version Bump
 
+**IMPORTANT**: Version must be bumped in the PR for CI to publish!
+
 Update version in `src/gac/__version__.py`:
 
 ```python
 __version__ = "0.15.0"  # new version
+```
+
+Or use `bump-my-version` tool:
+
+```bash
+# For bug fixes:
+bump-my-version bump patch
+
+# For new features:
+bump-my-version bump minor
+
+# For breaking changes:
+bump-my-version bump major
 ```
 
 Version numbering follows semantic versioning:
@@ -104,20 +119,19 @@ twine upload dist/*
 
 ### 7. Post-release
 
-1. **Create Git tag**:
+1. **Verify the release on PyPI**:
+
+   - Check [PyPI project page](https://pypi.org/project/gac/)
+   - Ensure the new version is listed
+
+2. **Optional: Create Git tag** (for reference):
 
    ```bash
    git tag -a v0.15.0 -m "Release version 0.15.0"
    git push origin v0.15.0
    ```
 
-2. **Create GitHub Release**:
-
-   - Go to [GitHub Releases](https://github.com/cellwebb/gac/releases)
-   - Click "Create a new release"
-   - Choose the tag you just created
-   - Add release notes from CHANGELOG.md
-   - Attach the wheel and tar.gz from `dist/`
+   Note: Tags are optional since CI publishes based on version changes, not tags.
 
 3. **Verify Installation**:
 
@@ -134,18 +148,20 @@ twine upload dist/*
 
 The project includes `.github/workflows/publish.yml` for automated releases:
 
-- Triggers on pushing tags matching `v*`
-- Automatically builds and publishes to PyPI
+- Triggers automatically when code is pushed to `main` branch
+- **Only publishes if the version in `src/gac/__version__.py` has been bumped**
 - Requires `PYPI_API_TOKEN` secret in repository settings
+- No manual tagging required
 
-To use automated release:
+### How it works
 
-```bash
-# Create and push tag
-git tag -a v0.15.0 -m "Release version 0.15.0"
-git push origin v0.15.0
-# GitHub Actions will handle the rest
-```
+1. Create a PR with your changes
+2. **Bump the version** in `src/gac/__version__.py`
+3. Update `CHANGELOG.md`
+4. Merge the PR to main
+5. CI automatically publishes to PyPI if version changed
+
+If the version hasn't been bumped, the CI will skip publishing (preventing duplicate uploads).
 
 ## Troubleshooting
 

--- a/src/gac/__version__.py
+++ b/src/gac/__version__.py
@@ -1,3 +1,3 @@
 """Version information for gac package."""
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"


### PR DESCRIPTION
## Summary
Switched from automatic releases on merge to tag-based releases for better control over when to publish to PyPI.

## Changes

### 1. **New Tag-Based Workflow** (`.github/workflows/publish.yml`)
- Triggers only when version tags are pushed (e.g., `v0.17.3`)
- Verifies tag version matches code version before publishing
- Prevents accidental releases and duplicate uploads
- Simple and predictable

### 2. **Updated Documentation**
- **RELEASING.md**: Clear instructions for tag-based releases
- **CONTRIBUTING.md**: Updated version bump guidelines
- **CHANGELOG.md**: Documented this workflow change

### 3. **Version Bump**: 0.17.2 → 0.17.3

## Benefits
✅ **Full control** - Decide exactly when to release
✅ **Batch releases** - Merge multiple PRs before releasing
✅ **No accidents** - Must explicitly create and push a tag
✅ **Clear history** - Tags mark exact release points
✅ **Industry standard** - Common pattern used by many projects

## New Release Process
1. Merge PR(s) with version bumped
2. When ready to release:
   ```bash
   git tag v0.17.3
   git push origin v0.17.3
   ```
3. GitHub Actions publishes to PyPI

## Test Plan
- [x] Verified tag version extraction logic
- [x] Tested version matching verification
- [x] Documentation is clear and complete
- [x] Workflow syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)